### PR TITLE
#101 @AuthenticationRequired + ArgumentResolver 이면 redis를 2번 조회하는 문제

### DIFF
--- a/src/main/java/com/bluedelivery/api/authentication/AuthenticatedUserArgumentResolver.java
+++ b/src/main/java/com/bluedelivery/api/authentication/AuthenticatedUserArgumentResolver.java
@@ -35,6 +35,9 @@ public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentR
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
+        if (Authentication.isAnnotated(parameter.getMethod())) {
+            return AuthenticationHolder.getAuthentication();
+        }
         HttpServletRequest req = (HttpServletRequest) webRequest.getNativeRequest();
         Optional<Authentication> optional = authenticationService.getAuthentication(req.getHeader(AUTHORIZATION));
         if (optional.isPresent()) {

--- a/src/main/java/com/bluedelivery/api/authentication/AuthenticatedUserArgumentResolver.java
+++ b/src/main/java/com/bluedelivery/api/authentication/AuthenticatedUserArgumentResolver.java
@@ -35,7 +35,7 @@ public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentR
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
-        if (Authentication.isAnnotated(parameter.getMethod())) {
+        if (AuthenticationHolder.hasAuthentication()) {
             return AuthenticationHolder.getAuthentication();
         }
         HttpServletRequest req = (HttpServletRequest) webRequest.getNativeRequest();

--- a/src/main/java/com/bluedelivery/api/authentication/AuthenticationHolder.java
+++ b/src/main/java/com/bluedelivery/api/authentication/AuthenticationHolder.java
@@ -5,6 +5,10 @@ import com.bluedelivery.domain.authentication.Authentication;
 public class AuthenticationHolder {
     private static ThreadLocal<Authentication> authentication = new ThreadLocal<>();
     
+    public static boolean hasAuthentication() {
+        return authentication.get() != null;
+    }
+    
     public static Authentication getAuthentication() {
         return authentication.get();
     }

--- a/src/main/java/com/bluedelivery/api/authentication/AuthenticationHolder.java
+++ b/src/main/java/com/bluedelivery/api/authentication/AuthenticationHolder.java
@@ -1,0 +1,15 @@
+package com.bluedelivery.api.authentication;
+
+import com.bluedelivery.domain.authentication.Authentication;
+
+public class AuthenticationHolder {
+    private static ThreadLocal<Authentication> authentication = new ThreadLocal<>();
+    
+    public static Authentication getAuthentication() {
+        return authentication.get();
+    }
+    
+    public static void setAuthentication(Authentication auth) {
+        authentication.set(auth);
+    }
+}

--- a/src/main/java/com/bluedelivery/domain/authentication/Authentication.java
+++ b/src/main/java/com/bluedelivery/domain/authentication/Authentication.java
@@ -1,9 +1,14 @@
 package com.bluedelivery.domain.authentication;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
+import com.bluedelivery.api.authentication.AuthenticationRequired;
 
 public class Authentication implements Serializable {
     public static String AUTH_STR = "auth";
@@ -19,6 +24,14 @@ public class Authentication implements Serializable {
     public Authentication(String token, Long userId) {
         this.token = token;
         this.userId = userId;
+    }
+    
+    public static boolean isAnnotated(Method method) {
+        if (AnnotationUtils.findAnnotation(method, AuthenticationRequired.class) == null
+                && AnnotationUtils.findAnnotation(method.getDeclaringClass(), AuthenticationRequired.class) == null) {
+            return false;
+        }
+        return true;
     }
     
     public void invalidate() {


### PR DESCRIPTION
#101 
@AuthenticationRequired 가 있으면 인터셉터에서 인증객체를 한번 조회하게 되는데, 
ArgumentResolver를 사용하는 경우에서도 인증객체를 조회하기 때문에 둘을 같이 사용하면 한 요청내에서 두 번의 조회가 발생합니다

그래서 인터셉터에서 조회한 객체를 ThreadLocal에 저장하고, ArgumentResolver에서 인증객체를 조회하기 전에 ThreadLocal을 먼저 확인하도록 변경하였습니다