### PR TITLE
#120 주문 가게 알림

### DIFF
--- a/src/main/java/com/bluedelivery/DeliveryApplication.java
+++ b/src/main/java/com/bluedelivery/DeliveryApplication.java
@@ -3,10 +3,12 @@ package com.bluedelivery;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class DeliveryApplication {
     public static void main(String[] args) {
         SpringApplication.run(DeliveryApplication.class, args);

--- a/src/main/java/com/bluedelivery/application/user/UserManagementService.java
+++ b/src/main/java/com/bluedelivery/application/user/UserManagementService.java
@@ -49,4 +49,5 @@ public interface UserManagementService {
      */
     boolean removeAddress(Long id, Long addressId);
     
+    User getUserById(Long id);
 }

--- a/src/main/java/com/bluedelivery/application/user/adapter/UserManagementServiceHttp.java
+++ b/src/main/java/com/bluedelivery/application/user/adapter/UserManagementServiceHttp.java
@@ -47,7 +47,7 @@ public class UserManagementServiceHttp implements UserManagementService {
     }
     
     public User updateAccount(UpdateAccountTarget param) {
-        User foundUser = getUserByIdAndCheckNotNull(param.getId());
+        User foundUser = getUserById(param.getId());
         foundUser.changePhone(param.getPhone());
         foundUser.changeNickname(param.getNickname());
         foundUser.setDateOfBirth(param.getDateOfBirth());
@@ -55,14 +55,14 @@ public class UserManagementServiceHttp implements UserManagementService {
     }
     
     public void deleteAccount(DeleteAccountTarget param) {
-        User user = getUserByIdAndCheckNotNull(param.getId());
+        User user = getUserById(param.getId());
         user.validate(param.getPassword());
         userRepository.delete(user);
     }
     
     @Override
     public Address addAddress(AddAddressTarget param) {
-        User user = getUserByIdAndCheckNotNull(param.getId());
+        User user = getUserById(param.getId());
         BuildingInfo buildingInfo =
                 addressService.getBuildingAddress(param.getBuildingManagementNumber());
         Address address = new Address(buildingInfo, param.getDetail());
@@ -72,19 +72,20 @@ public class UserManagementServiceHttp implements UserManagementService {
     
     @Override
     public boolean setMainAddress(Long userId, Long addressId) {
-        User user = getUserByIdAndCheckNotNull(userId);
+        User user = getUserById(userId);
         Address address = addressService.getAddress(addressId, user);
         return user.designateAsMainAddress(address);
     }
     
     @Override
     public boolean removeAddress(Long userId, Long addressId) {
-        User user = getUserByIdAndCheckNotNull(userId);
+        User user = getUserById(userId);
         Address address = addressService.getAddress(addressId, user);
         return user.removeAddress(address);
     }
     
-    private User getUserByIdAndCheckNotNull(Long id) {
+    @Override
+    public User getUserById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
     }

--- a/src/main/java/com/bluedelivery/common/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/bluedelivery/common/config/GlobalExceptionHandler.java
@@ -25,12 +25,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<HttpResponse> apiExceptionHandler(final ApiException ex) {
         ErrorCode error = ex.getError();
+        HttpResponse body = new HttpResponse(error.getStatus(), error.getMessage());
+        log.error("#### API EXCEPTION - " + body);
         return ResponseEntity
                 .status(error.getHttpStatus())
-                .body(new HttpResponse(
-                        error.getStatus(),
-                        error.getMessage()
-                ));
+                .body(body);
     }
 
     // 400

--- a/src/main/java/com/bluedelivery/common/config/RedisConfig.java
+++ b/src/main/java/com/bluedelivery/common/config/RedisConfig.java
@@ -13,6 +13,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import com.bluedelivery.domain.authentication.Authentication;
 import com.bluedelivery.domain.authentication.AuthenticationRepository;
 import com.bluedelivery.infra.authentication.AuthenticationRedisRepository;
+import com.bluedelivery.order.infra.OrderNotification;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -53,6 +54,19 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(jedisConnectionFactory());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(serializer);
+        return redisTemplate;
+    }
+    
+    @Bean
+    public RedisTemplate<String, OrderNotification> orderNotificationRedisTemplate(
+            ObjectMapper om, RedisConnectionFactory rcf) {
+        var serializer = new Jackson2JsonRedisSerializer<>(OrderNotification.class);
+        var redisTemplate = new RedisTemplate<String, OrderNotification>();
+        serializer.setObjectMapper(om);
+        redisTemplate.setConnectionFactory(rcf);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
     }
     

--- a/src/main/java/com/bluedelivery/common/response/HttpResponse.java
+++ b/src/main/java/com/bluedelivery/common/response/HttpResponse.java
@@ -2,6 +2,9 @@ package com.bluedelivery.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import lombok.ToString;
+
+@ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class HttpResponse<T> {
 

--- a/src/main/java/com/bluedelivery/domain/user/User.java
+++ b/src/main/java/com/bluedelivery/domain/user/User.java
@@ -87,8 +87,8 @@ public class User {
         this.dateOfBirth = dateOfBirth;
     }
     
-    public Addresses getAddresses() {
-        return addresses;
+    public Address getMainAddress() {
+        return addresses.getMainAddress();
     }
     
     public boolean designateAsMainAddress(Address address) {

--- a/src/main/java/com/bluedelivery/notification/Notification.java
+++ b/src/main/java/com/bluedelivery/notification/Notification.java
@@ -1,0 +1,29 @@
+package com.bluedelivery.notification;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Notification {
+    
+    @Id
+    @GeneratedValue
+    private Long notificationId;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime expire;
+    
+    
+    public Notification() {
+    
+    }
+    
+    public Notification(String content) {
+        this.content = content;
+        createdAt = LocalDateTime.now();
+        expire = createdAt.plusMinutes(1);
+    }
+}

--- a/src/main/java/com/bluedelivery/notification/NotificationRepository.java
+++ b/src/main/java/com/bluedelivery/notification/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.bluedelivery.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/bluedelivery/notification/NotificationService.java
+++ b/src/main/java/com/bluedelivery/notification/NotificationService.java
@@ -1,9 +1,20 @@
 package com.bluedelivery.notification;
 
+import static com.bluedelivery.notification.ThirdPartyNotifier.*;
+
+import java.util.Set;
+
+import javax.transaction.Transactional;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 import com.bluedelivery.order.infra.OrderNotification;
-import com.bluedelivery.order.infra.OrderNotificationRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,13 +24,34 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class NotificationService {
     
-    private final OrderNotificationRepository orderNotificationRepository;
+    private final ApplicationEventPublisher publisher;
+    private final RedisTemplate<String, OrderNotification> redisTemplate;
     
+    @Transactional
     public void notifyOrder() {
-        Iterable<OrderNotification> events = orderNotificationRepository.findAll();
+        redisTemplate.execute(requestNotification());
+    }
+    
+    private SessionCallback<Object> requestNotification() {
+        return new SessionCallback<>() {
+            @Override
+            public Object execute(RedisOperations operations) throws DataAccessException {
+                operations.multi(); // transaction
+                SetOperations ops = operations.opsForSet();
+                Set<OrderNotification> events = ops.members(OrderNotification.key);
+                if (!events.isEmpty()) {
+                    send(ops, events);
+                }
+                return operations.exec();
+            }
+        };
+    }
+    
+    private void send(SetOperations<String, OrderNotification> ops, Set<OrderNotification> events) {
         for (OrderNotification event : events) {
             log.info("제 3자 서비스로 전송 : " + event);
+            publisher.publishEvent(new ACompanyNotificationEvent(event));
         }
-        orderNotificationRepository.deleteAll(events);
+        ops.remove(OrderNotification.key, events.toArray(new OrderNotification[0]));
     }
 }

--- a/src/main/java/com/bluedelivery/notification/NotificationService.java
+++ b/src/main/java/com/bluedelivery/notification/NotificationService.java
@@ -1,0 +1,25 @@
+package com.bluedelivery.notification;
+
+import org.springframework.stereotype.Service;
+
+import com.bluedelivery.order.infra.OrderNotification;
+import com.bluedelivery.order.infra.OrderNotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+    
+    private final OrderNotificationRepository orderNotificationRepository;
+    
+    public void notifyOrder() {
+        Iterable<OrderNotification> events = orderNotificationRepository.findAll();
+        for (OrderNotification event : events) {
+            log.info("제 3자 서비스로 전송 : " + event);
+        }
+        orderNotificationRepository.deleteAll(events);
+    }
+}

--- a/src/main/java/com/bluedelivery/notification/OrderNotificationScheduler.java
+++ b/src/main/java/com/bluedelivery/notification/OrderNotificationScheduler.java
@@ -1,0 +1,26 @@
+package com.bluedelivery.notification;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderNotificationScheduler {
+    
+    private final NotificationService notificationService;
+    
+    @Scheduled(fixedDelay = 1000L * 60 * 3, initialDelay = 1000L)
+    public void lookupFailedNotifications() {
+        try {
+            log.info("주문 알림을 재전송합니다. ");
+            notificationService.notifyOrder();
+        } catch (RuntimeException exception) {
+            log.error("주문 알림 재전송 실패 : " + exception);
+            throw new IllegalStateException("재전송 실패 : " + exception);
+        }
+    }
+}

--- a/src/main/java/com/bluedelivery/notification/OrderNotificationScheduler.java
+++ b/src/main/java/com/bluedelivery/notification/OrderNotificationScheduler.java
@@ -13,14 +13,14 @@ public class OrderNotificationScheduler {
     
     private final NotificationService notificationService;
     
-    @Scheduled(fixedDelay = 1000L * 60 * 3, initialDelay = 1000L)
-    public void lookupFailedNotifications() {
+    @Scheduled(fixedDelay = 1000L * 30, initialDelay = 1000L)
+    public void lookupNotifications() {
         try {
-            log.info("주문 알림을 재전송합니다. ");
+            log.info("주문 알림을 전송합니다. ");
             notificationService.notifyOrder();
         } catch (RuntimeException exception) {
-            log.error("주문 알림 재전송 실패 : " + exception);
-            throw new IllegalStateException("재전송 실패 : " + exception);
+            log.error("주문 알림 전송 실패 : " + exception);
+            throw new IllegalStateException("주문 알림 전송 실패 : " + exception);
         }
     }
 }

--- a/src/main/java/com/bluedelivery/notification/ThirdPartyEventListener.java
+++ b/src/main/java/com/bluedelivery/notification/ThirdPartyEventListener.java
@@ -1,0 +1,32 @@
+package com.bluedelivery.notification;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.bluedelivery.order.infra.OrderNotification;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class ThirdPartyEventListener {
+    
+    private final ThirdPartyNotifier thirdPartyNotifier;
+    private final RedisTemplate<String, OrderNotification> redisTemplate;
+    
+    // NotificationService -> 제3서비스가 하나로 묶이면 실패하는 알림이 생기면 전체 알림이 취소될 수 있다.
+    // 그래서 이벤트를 발행해서 각각 처리될 수 있도록 하고 실패한 알림은 다시 redis에 저장한다.
+    @Async
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @TransactionalEventListener
+    public void request(ThirdPartyNotifier.ACompanyNotificationEvent form) {
+        boolean succeed = thirdPartyNotifier.request(form);
+        if (!succeed) {
+            redisTemplate.opsForSet().add(OrderNotification.key, form.getOrderNotification());
+        }
+    }
+}

--- a/src/main/java/com/bluedelivery/notification/ThirdPartyNotifier.java
+++ b/src/main/java/com/bluedelivery/notification/ThirdPartyNotifier.java
@@ -1,0 +1,39 @@
+package com.bluedelivery.notification;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+
+import com.bluedelivery.order.infra.OrderNotification;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ThirdPartyNotifier { // 가짜 서비스. 랜덤숫자 5가 나오면 알림 전송에 실패함
+    public boolean request(ACompanyNotificationEvent form) {
+        try {
+            Thread.sleep(300L);
+        } catch (InterruptedException ignored) {
+        
+        }
+        ThreadLocalRandom current = ThreadLocalRandom.current();
+        int random = current.nextInt(10);
+        if (random == 5) {
+            log.error("3rd party form : fail = " + form.getOrderNotification());
+            return false;
+        }
+        log.info("3rd party form : succeed = " + form.getOrderNotification());
+        return true;
+    }
+    
+    @Data
+    public static class ACompanyNotificationEvent {
+        private OrderNotification orderNotification;
+    
+        public ACompanyNotificationEvent(OrderNotification orderNotification) {
+            this.orderNotification = orderNotification;
+        }
+    }
+}

--- a/src/main/java/com/bluedelivery/order/application/SearchOrderService.java
+++ b/src/main/java/com/bluedelivery/order/application/SearchOrderService.java
@@ -1,0 +1,24 @@
+package com.bluedelivery.order.application;
+
+import org.springframework.stereotype.Service;
+
+import com.bluedelivery.order.domain.Order;
+import com.bluedelivery.order.domain.OrderDetails;
+import com.bluedelivery.order.domain.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class SearchOrderService {
+    
+    private final OrderRepository orderRepository;
+    
+    // TODO 구현예정(주문상세조회)
+    public OrderDetails getOrderDetails(Long orderId) {
+        Order order = orderRepository.getFlatOrderById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("empty order"));
+        OrderDetails details = new OrderDetails(order.getOrderItems());
+        return details;
+    }
+}

--- a/src/main/java/com/bluedelivery/order/application/impl/OrderHttpService.java
+++ b/src/main/java/com/bluedelivery/order/application/impl/OrderHttpService.java
@@ -30,12 +30,7 @@ public class OrderHttpService implements OrderService {
         Payment payment = paymentService.process(new Payment.PaymentForm(order));
         order.pay(payment);
         orderRepository.save(order);
-        publisher.publishEvent(new OrderedNotificationEvent(
-                order.getOrderId(),
-                order.getShopId(),
-                order.getUserId(),
-                order.getPaymentId()
-        ));
+        publisher.publishEvent(new OrderedNotificationEvent(order));
         return order;
     }
 

--- a/src/main/java/com/bluedelivery/order/domain/Order.java
+++ b/src/main/java/com/bluedelivery/order/domain/Order.java
@@ -67,6 +67,14 @@ public class Order {
         this.paymentId = payment.id();
     }
     
+    public OrderStatus getOrderStatus() {
+        return orderStatus;
+    }
+    
+    public List<OrderItem> getOrderItems() {
+        return orderItems;
+    }
+    
     public List<Long> getOrderItemIds() {
         return orderItems.stream().map(OrderItem::getMenuId).collect(toList());
     }
@@ -89,6 +97,10 @@ public class Order {
     
     public Long getShopId() {
         return shopId;
+    }
+    
+    public Long getPaymentId() {
+        return paymentId;
     }
     
     public void isValidMenu(List<Menu> menus) {

--- a/src/main/java/com/bluedelivery/order/domain/OrderDetails.java
+++ b/src/main/java/com/bluedelivery/order/domain/OrderDetails.java
@@ -1,0 +1,14 @@
+package com.bluedelivery.order.domain;
+
+import java.util.List;
+
+import lombok.Getter;
+
+// TODO 구현예정(주문상세조회)
+@Getter
+public class OrderDetails {
+    private List<OrderItem> orderItems;
+    public OrderDetails(List<OrderItem> orderItems) {
+        this.orderItems = orderItems;
+    }
+}

--- a/src/main/java/com/bluedelivery/order/domain/OrderItem.java
+++ b/src/main/java/com/bluedelivery/order/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package com.bluedelivery.order.domain;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/bluedelivery/order/domain/OrderRepository.java
+++ b/src/main/java/com/bluedelivery/order/domain/OrderRepository.java
@@ -1,8 +1,14 @@
 package com.bluedelivery.order.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    
+    @Query("select o from Order o join fetch o.orderItems oi where o.orderId = :orderId")
+    Optional<Order> getFlatOrderById(Long orderId);
 }

--- a/src/main/java/com/bluedelivery/order/infra/OrderNotification.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderNotification.java
@@ -2,47 +2,56 @@ package com.bluedelivery.order.infra;
 
 import java.util.List;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
-
-import com.bluedelivery.domain.address.Address;
 import com.bluedelivery.order.domain.OrderDetails;
 import com.bluedelivery.order.domain.OrderItem;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
+
+@ToString
 @Getter
-@RedisHash("notification:ordered")
-public class OrderNotification {
-    @Id
+public class OrderNotification { // TODO 수정예정(주문상세조회 후)
+    public static final String key = "notification:ordered";
+    
     private Long orderId;
     private String username;
     private String userPhone;
-    private Address address;
     private List<OrderItem> orderItems;
     private int paymentAmount;
     
+    public OrderNotification() {
+    }
+    
     @Builder
-    public OrderNotification(Long orderId, String username, String userPhone, Address address,
+    public OrderNotification(Long orderId, String username, String userPhone,
                              List<OrderItem> orderItems, int paymentAmount) {
         this.orderId = orderId;
         this.username = username;
         this.userPhone = userPhone;
-        this.address = address;
         this.orderItems = orderItems;
         this.paymentAmount = paymentAmount;
     }
     
-    // TODO 수정예정(주문상세조회 후)
     public static OrderNotification from(OrderDetails details) {
         return OrderNotification.builder()
                 .orderId(1L)
                 .username("username")
                 .userPhone("01012341234")
-                .address(new Address())
                 .orderItems(details.getOrderItems())
                 .paymentAmount(10000)
                 .build();
+    }
+    
+    public String serializeJson() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 }

--- a/src/main/java/com/bluedelivery/order/infra/OrderNotification.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderNotification.java
@@ -1,0 +1,48 @@
+package com.bluedelivery.order.infra;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.bluedelivery.domain.address.Address;
+import com.bluedelivery.order.domain.OrderDetails;
+import com.bluedelivery.order.domain.OrderItem;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@RedisHash("notification:ordered")
+public class OrderNotification {
+    @Id
+    private Long orderId;
+    private String username;
+    private String userPhone;
+    private Address address;
+    private List<OrderItem> orderItems;
+    private int paymentAmount;
+    
+    @Builder
+    public OrderNotification(Long orderId, String username, String userPhone, Address address,
+                             List<OrderItem> orderItems, int paymentAmount) {
+        this.orderId = orderId;
+        this.username = username;
+        this.userPhone = userPhone;
+        this.address = address;
+        this.orderItems = orderItems;
+        this.paymentAmount = paymentAmount;
+    }
+    
+    // TODO 수정예정(주문상세조회 후)
+    public static OrderNotification from(OrderDetails details) {
+        return OrderNotification.builder()
+                .orderId(1L)
+                .username("username")
+                .userPhone("01012341234")
+                .address(new Address())
+                .orderItems(details.getOrderItems())
+                .paymentAmount(10000)
+                .build();
+    }
+}

--- a/src/main/java/com/bluedelivery/order/infra/OrderNotificationRepository.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderNotificationRepository.java
@@ -1,0 +1,7 @@
+package com.bluedelivery.order.infra;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+public interface OrderNotificationRepository extends CrudRepository<OrderNotification, Long> {
+}

--- a/src/main/java/com/bluedelivery/order/infra/OrderNotificationRepository.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderNotificationRepository.java
@@ -1,7 +1,0 @@
-package com.bluedelivery.order.infra;
-
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
-
-public interface OrderNotificationRepository extends CrudRepository<OrderNotification, Long> {
-}

--- a/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
@@ -24,12 +24,8 @@ public class OrderedEventHandler {
     @TransactionalEventListener
     public void notifyOrderToShop(OrderedNotificationEvent event) {
         log.info("알림 이벤트 발생 orderId: " + event.getOrderId());
-        try {
-            OrderDetails details = searchOrderService.getOrderDetails(event.getOrderId());
-            orderNotificationRepository.save(OrderNotification.from(details));
-        } catch (Exception e) {
-            log.error(String.valueOf(e));
-        }
+        OrderDetails details = searchOrderService.getOrderDetails(event.getOrderId());
+        orderNotificationRepository.save(OrderNotification.from(details));
     }
     
     @Data

--- a/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
@@ -1,0 +1,43 @@
+package com.bluedelivery.order.infra;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.bluedelivery.order.application.SearchOrderService;
+import com.bluedelivery.order.domain.OrderDetails;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderedEventHandler {
+    
+    private final OrderNotificationRepository orderNotificationRepository;
+    private final SearchOrderService searchOrderService;
+    
+    @Async
+    @TransactionalEventListener
+    public void notifyOrderToShop(OrderedNotificationEvent event) {
+        log.info("알림 이벤트 발생 orderId: " + event.getOrderId());
+        try {
+            OrderDetails details = searchOrderService.getOrderDetails(event.getOrderId());
+            orderNotificationRepository.save(OrderNotification.from(details));
+        } catch (Exception e) {
+            log.error(String.valueOf(e));
+        }
+    }
+    
+    @Data
+    @AllArgsConstructor
+    public static class OrderedNotificationEvent {
+        private Long orderId;
+        private Long shopId;
+        private Long userId;
+        private Long paymentId;
+    }
+}

--- a/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
+++ b/src/main/java/com/bluedelivery/order/infra/OrderedEventHandler.java
@@ -1,10 +1,16 @@
 package com.bluedelivery.order.infra;
 
+import javax.transaction.Transactional;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.bluedelivery.notification.Notification;
+import com.bluedelivery.notification.NotificationRepository;
 import com.bluedelivery.order.application.SearchOrderService;
+import com.bluedelivery.order.domain.Order;
 import com.bluedelivery.order.domain.OrderDetails;
 
 import lombok.AllArgsConstructor;
@@ -17,23 +23,24 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class OrderedEventHandler {
     
-    private final OrderNotificationRepository orderNotificationRepository;
+    private final RedisTemplate<String, OrderNotification> redisTemplate;
     private final SearchOrderService searchOrderService;
+    private final NotificationRepository notificationRepository;
     
     @Async
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
     @TransactionalEventListener
     public void notifyOrderToShop(OrderedNotificationEvent event) {
-        log.info("알림 이벤트 발생 orderId: " + event.getOrderId());
-        OrderDetails details = searchOrderService.getOrderDetails(event.getOrderId());
-        orderNotificationRepository.save(OrderNotification.from(details));
+        log.info("알림 이벤트 발생 orderId: " + event.getOrder().getOrderId());
+        OrderDetails details = searchOrderService.getOrderDetails(event.getOrder().getOrderId());
+        OrderNotification notification = OrderNotification.from(details);
+        redisTemplate.boundSetOps(OrderNotification.key).add(notification);
+        notificationRepository.save(new Notification(notification.serializeJson()));
     }
     
     @Data
     @AllArgsConstructor
     public static class OrderedNotificationEvent {
-        private Long orderId;
-        private Long shopId;
-        private Long userId;
-        private Long paymentId;
+        private Order order;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
 
   redis:
     host: localhost

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
   redis:
     host: localhost

--- a/src/main/resources/db/migration/V202108211700__ddl_notification.sql
+++ b/src/main/resources/db/migration/V202108211700__ddl_notification.sql
@@ -1,0 +1,6 @@
+CREATE TABLE NOTIFICATION (
+    NOTIFICATION_ID bigint auto auto_increment,
+    CONTENT varchar(10000),
+    date,
+    primary key (NOTIFICATION_ID)
+);

--- a/src/test/java/com/bluedelivery/order/application/impl/OrderServiceTest.java
+++ b/src/test/java/com/bluedelivery/order/application/impl/OrderServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.bluedelivery.order.application.OrderService;
 import com.bluedelivery.order.domain.Order;
@@ -32,6 +33,9 @@ class OrderServiceTest {
     @Mock
     private PaymentService paymentService;
     
+    @Mock
+    private ApplicationEventPublisher publisher;
+    
     private Order.OrderForm form;
     private Order order;
     private Payment.PaymentForm paymentForm;
@@ -39,7 +43,7 @@ class OrderServiceTest {
     
     @BeforeEach
     void setup() {
-        orderService = new OrderHttpService(orderRepository, orderMapper, paymentService);
+        orderService = new OrderHttpService(orderRepository, orderMapper, paymentService, publisher);
         form = orderForm().build();
         order = form.createOrder();
         paymentForm = new Payment.PaymentForm(order);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23302253/130066895-069b743d-e2ab-4157-a6a4-bf0289c4907d.png)
> 그림에서는 `OrederedEventHandler`가 트랜잭션으로 표시되있지만, 레디스 트랜잭션 설정을 false로 해놓은 상태입니다

다음 두가지 위주로 고민했습니다
- 메세지큐를 써보기 전에 어떻게 알림 전송을 eventual consistency 로 구현할 수 있을지
-  '주문'과 '알림'의 트랜잭션을 분리

**eventual consistency**
- `OrderedEventHandler`에서  이벤트를 모두 redis에 저장만하고 책임을 마칩니다.  
- 그리고 `OrderNotificationScheduler`가 주기적으로 redis를 조회하고, 한번에 이벤트들을 꺼내서 보냅니다. 
    -  현재 3분으로 되어있는데, 너무 긴듯 해서 고민중입니다
- 보낸 이벤트들은 redis에서 삭제합니다

**트랜잭션**
주문 코드와 알림 코드의 결합도를 낮추기 위해 이벤트 리스너를 사용했는데, 알림 과정에서 문제가 생겨도 Order는 정상적으로 처리될 수 있게 트랜잭션을 분리하고자 멘토님이 말씀해주신 `@TransactionalEventListner`를 알아보고 사용했습니다
- 이벤트 시점을 조절할 수 있게 해주고, default phase인 AFTER_COMMIT은 이전 트랜잭션이 COMMIT 된 이후 시점에 이벤트를 발생시킴
- 하지만 새로운 트랜잭션이 아닌 COMMIT한 기존 트랜잭션에 참여하기 때문에, 수정을 발생시키고 재 COMMIT은 불가능
    -   BEFORE_COMMIT을 하면 COMMIT은 가능해지지만, 주문과 알림 트랜잭션이 묶임
    -  그래서 만약 변경이 필요하게 되면 `@Transactional` 의 propagation을 REQUIRES_NEW로 바꿔서 새로운 트랜잭션을 만들어야함


실제 알림은 아직 구현하지 않았고 NotificationService 에서 로그로 대신했습니다 

--- 
이 외에도 
- restTemplate로 직접 알림 api를 먼저 호출한 후, redis에 실패한 이벤트만 저장 
- -> 스케줄러로 실패한 이벤트만 조회후 api 호출 재시도

하는 방법도 시도해봤는데, 이 경우 처음에 알림api를 호출하면 이 작업이 끝날때 까지 기다려야하고, 동시에 스케줄러도 도는게 괜찮은 방법같지 않아서 위의 방법으로 수정했습니다
